### PR TITLE
Add custom modem settings

### DIFF
--- a/arduino/gateway/config.h
+++ b/arduino/gateway/config.h
@@ -7,6 +7,8 @@
 //#define CALLSIGN "MYCALLSIGN-5"
 //#define BANNER "SomeRadio solar digipeater mAh=1234"
 
+// uncomment to use with PocketCHIP
+// #define Serial Serial1
 
 // Define your hardware type both here and in Toos/Board.
 #define FEATHER_M0
@@ -27,11 +29,13 @@
 #define LED 13
 
 // LED debug options
-// #define DEBUG_LED_XMIT
-#define DEBUG_LED_RTC
+#define DEBUG_LED_XMIT
+// #define DEBUG_LED_RTC
+
+#define BATTERY_SAVING false
 
 // use RTC.  This helps power consumption, but totally bricks USB.
-//#define RTC_ENABLED
+// #define RTC_ENABLED
 
 // Repeat incoming packets.
 // Only use this for nodes with good antenna placement.
@@ -40,8 +44,8 @@
 
 // Periodic beaconing.
 #define BEACON_PERIODIC
-#define BEACON_PERIOD (60 * 10 * 1000) // ms
-#define BEACON_PERIOD_LOWBATT (60 * 20 * 1000) // ms
+#define BEACON_PERIOD (60 * 20 * 1000) // ms
+#define BEACON_PERIOD_LOWBATT (60 * 30 * 1000) // ms
 
 #define LOWBATT_WAIT_PERIOD (60 * 20 * 1000) // ms
 
@@ -49,7 +53,7 @@
 #define BUFFER_PACKETS 10
 
 // max xmit wait - we'll wait between 0 and n milliseconds before transmitting to avoid collision
-#define MAX_XMIT_WAIT 10000
+#define MAX_XMIT_WAIT 20000
 
 // These voltage thresholds are used for power management.
 #define RADIO_CONTINUOUS_VOLTAGE 3.9  // Begin repeating above this voltage.

--- a/arduino/gateway/gateway.ino
+++ b/arduino/gateway/gateway.ino
@@ -59,12 +59,12 @@ void loop() {
   switch(mode) {
     case MODE_OFF:
       sleepreset(0);
-      if(voltage() < MIN_XMIT_VOLTAGE) {
+      if(BATTERY_SAVING && voltage() < MIN_XMIT_VOLTAGE) {
         radiooff();
         mode = MODE_LOWBATT;
       } else {
         radioon();
-        if(voltage() > RADIO_CONTINUOUS_VOLTAGE) {
+        if(!BATTERY_SAVING || voltage() > RADIO_CONTINUOUS_VOLTAGE) {
           beacon("Powered on!");
           xmitstack();
           mode = MODE_CONTINUOUS;
@@ -77,7 +77,7 @@ void loop() {
       }
       break;
     case MODE_CONTINUOUS:
-      if(voltage() < MIN_XMIT_VOLTAGE) {
+      if(BATTERY_SAVING && voltage() < MIN_XMIT_VOLTAGE) {
         beacon("Entering transmit only mode.");
         xmitstack();
         radiooff();

--- a/arduino/gateway/network.cpp
+++ b/arduino/gateway/network.cpp
@@ -68,6 +68,15 @@ void radioon() {
     delay(10000);
   }
 
+  RH_RF95::ModemConfig modemconfig = {
+    // see pg 106 http://www.hoperf.com/upload/rf/RFM95_96_97_98W.pdf
+    0x76, // reg 1D - 125kHz, 4/7
+    0xc4, // reg 1E - SF=12, CRC on
+    0x0c  // reg 26 - low data rate on, AGC on
+  };
+
+  rf95.setModemRegisters(&modemconfig);
+
   // Defaults after init are 434.0MHz, modulation GFSK_Rb250Fd250, +13dbM
   if (!rf95.setFrequency(RF95_FREQ)) {
     Serial.println("# setFrequency failed");
@@ -75,8 +84,6 @@ void radioon() {
   } else {
     Serial.print("# Set Freq to: "); Serial.println(RF95_FREQ);
   }
-
-  // Defaults after init are 434.0MHz, 13dBm, Bw = 125 kHz, Cr = 4/5, Sf = 128chips/symbol, CRC on
 
   // The default transmitter power is 13dBm, using PA_BOOST.
   // If you are using RFM95/96/97/98 modules which uses the PA_BOOST transmitter pin, then
@@ -177,7 +184,7 @@ bool digipeat(uint8_t *pkt, int rssi) {
 
 // transmits all the packets in the xmit stack, while receiving any that come in
 void xmitstack() {
-  int delaytime = random(MAX_XMIT_WAIT) + 10000; // add 10 seconds to prevent simple_gateway from throwing packets away
+  int delaytime = random(MAX_XMIT_WAIT) + 2000; // add 2 seconds in case another packet is on its way
   bool delayed = false;
   while (xmitbufi > -1) {
     if (!delayed && xmitbuf[xmitbufi].delay) {


### PR DESCRIPTION
* Adds a new configuration for the modem: SF=12, Cr=4/7, Bw=125kHz, CRC on, Low data rate optimization on
    * Spreading factor 12, 4096 chips/symbol, is the slowest but gets us more link budget: 12.5dB more than what we were using previously according to the [RF96 datasheet, p24](http://www.hoperf.com/upload/rf/RFM95_96_97_98W.pdf)
    * Coding rate 4/7 was identified as being the best value by @matt-knight in #14
    * Bandwidth left as is. Could use more discussion
    * Low data rate optimization is enabled, as it's needed at larger time scales. This somehow makes the LoRa packets resistant to receiver and transmitter becoming unsynchronized
* Changes default beacon period to 20 minutes, to prepare the network for slower data rates
* Unrelated: adds `BATTERY_SAVING` constant so we can turn off battery saving modes completely on radios connected to computer or PocketCHIP, for example

[This post](https://lowpowerlab.com/forum/general-topics/issue-with-lora-long-range-modes-and-rfm95rfm96/msg15186/#msg15186) was helpful in finding the barely documented bit for low data rate optimization mode.

This is just a first pass, which will hopefully generate more discussion in issue #14 about the best configuration to use. Let's hold off on merging pending discussion about bandwidth and if there are differing opinions about the other settings.